### PR TITLE
Add PayPal BN Code to Braintree Gateways

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,5 +6,4 @@ gem 'workarea', github: 'workarea-commerce/workarea', branch: 'v3.5-stable'
 
 group :test do
   gem "workarea-testing"
-  gem "simplecov-bamboo", require: false
 end

--- a/lib/workarea/braintree.rb
+++ b/lib/workarea/braintree.rb
@@ -3,6 +3,11 @@ require "workarea/braintree/version"
 
 require "active_merchant/billing/bogus_braintree_gateway"
 
+# Don't change this value, it's needed for PayPal revenue attribution
+ActiveMerchant::Billing::BraintreeBlueGateway.application_id = 'Workarea_SP_PCP'
+ActiveMerchant::Billing::BraintreeOrangeGateway.application_id = 'Workarea_SP_PCP'
+ActiveMerchant::Billing::BogusBraintreeGateway.application_id = 'Workarea_SP_PCP'
+
 module Workarea
   module Braintree
     def self.auto_configure_gateway

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,3 @@
-require 'simplecov'
-
-SimpleCov.start "rails" do
-  add_filter "version.rb"
-  add_filter "lib/active_merchant/billing/bogus_braintree_gateway.rb"
-end
-
 ENV['RAILS_ENV'] = 'test'
 
 require File.expand_path("../../test/dummy/config/environment.rb", __FILE__)


### PR DESCRIPTION
The BN code for PayPal revenue attribution has now been added to all
Braintree gateway requests using the global `.application_id` parameter.
This maps to the `:channel` in Braintree's API.

**More info:**
- https://developers.braintreepayments.com/reference/request/transaction/sale/ruby#channel
- https://github.com/activemerchant/active_merchant/blob/master/lib/active_merchant/billing/gateways/braintree_blue.rb#L608