### PR TITLE
Add PayPal BN Code to Braintree Gateways

### DIFF
--- a/lib/workarea/braintree.rb
+++ b/lib/workarea/braintree.rb
@@ -4,16 +4,19 @@ require "workarea/braintree/version"
 require "active_merchant/billing/bogus_braintree_gateway"
 
 # Don't change this value, it's needed for attribution
-ActiveMerchant::Billing::BraintreeBlueGateway.application_id = 'Workarea_SP_PCP'
-ActiveMerchant::Billing::BraintreeOrangeGateway.application_id = 'Workarea_SP_PCP'
-ActiveMerchant::Billing::BogusBraintreeGateway.application_id = 'Workarea_SP_PCP'
+ActiveMerchant::Billing::BraintreeBlueGateway.application_id = 'Workarea_SP'
+ActiveMerchant::Billing::BraintreeOrangeGateway.application_id = 'Workarea_SP'
+ActiveMerchant::Billing::BogusBraintreeGateway.application_id = 'Workarea_SP'
 
 module Workarea
   module Braintree
     def self.auto_configure_gateway
       if Rails.application.secrets.braintree.present?
         self.gateway = ActiveMerchant::Billing::BraintreeGateway.new(
-          Rails.application.secrets.braintree.deep_symbolize_keys
+          Rails.application.secrets.braintree.deep_symbolize_keys.merge(
+            # Do not change this
+            channel: 'Workarea_SP'
+          )
         )
       else
         self.gateway = ActiveMerchant::Billing::BogusBraintreeGateway.new


### PR DESCRIPTION
The BN code for PayPal revenue attribution has now been added to all Braintree gateway requests using the global `.application_id` parameter.  This maps the `:channel` in Braintree's API to the BN code set on the class level.